### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,8 @@
 name: CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, main ]


### PR DESCRIPTION
Potential fix for [https://github.com/dchou1618/python-examples/security/code-scanning/2](https://github.com/dchou1618/python-examples/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/cicd.yml` so all jobs inherit restricted token access by default.

Best minimal fix (no functionality change): add
```yaml
permissions:
  contents: read
```
directly under `name` (or under `on`, before `jobs`).  
This satisfies checkout and typical read operations while preventing unnecessary write scope. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
