### PR TITLE
ci: caching for pytest and pip to speed CI reruns

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,4 +52,3 @@ jobs:
       - name: Run tests with coverage
         run: |
           pytest -q --cov=Algorithms --cov-report=term-missing --cov-fail-under=80
-

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,6 +22,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt','requirements-dev.txt','pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Cache pytest discovery
+        uses: actions/cache@v4
+        with:
+          path: .pytest_cache
+          key: ${{ runner.os }}-pytest-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pytest-${{ matrix.python-version }}-
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Add caching steps for pip downloads and pytest discovery cache to speed CI reruns and reduce redundant test collection.